### PR TITLE
2017.3 sofair

### DIFF
--- a/src/main/kotlin/org/jetbrains/fortran/ide/typing/FortranEnterHandler.kt
+++ b/src/main/kotlin/org/jetbrains/fortran/ide/typing/FortranEnterHandler.kt
@@ -137,9 +137,9 @@ class FortranEnterHandler : EnterHandlerDelegateAdapter() {
         2 -> {endString = endString.toUpperCase()}
         }
         if (constructName != null){
-            editor.document.insertString(offset, "\n!${indentString}${nodeTextFirstLine}\n${indentString}${endString} $constructName")
+            editor.document.insertString(offset, "\n${indentString}${endString} $constructName")
         } else {
-            editor.document.insertString(offset, "\n!${indentString}${nodeTextFirstLine}\n${indentString}${endString}")
+            editor.document.insertString(offset, "\n${indentString}${endString}")
         }
     }
     

--- a/src/main/kotlin/org/jetbrains/fortran/ide/typing/FortranEnterHandler.kt
+++ b/src/main/kotlin/org/jetbrains/fortran/ide/typing/FortranEnterHandler.kt
@@ -56,6 +56,21 @@ class FortranEnterHandler : EnterHandlerDelegateAdapter() {
                 return EnterHandlerDelegate.Result.DefaultForceIndent
             }
 
+            // subroutine subprogram
+            is FortranSubroutineSubprogram -> if (constructOrUnit.endSubroutineStmt == null) {
+                val programUnitName = constructOrUnit.beginUnitStmt!!.entityDecl!!.name
+                editor.document.insertString(offset, "\n${indentString}end ${constructOrUnit.unitType} $programUnitName")
+                return EnterHandlerDelegate.Result.DefaultForceIndent
+            }
+
+            // function subprogram
+            is FortranFunctionSubprogram -> if (constructOrUnit.endFunctionStmt == null) {
+                val programUnitName = constructOrUnit.beginUnitStmt!!.entityDecl!!.name
+                editor.document.insertString(offset, "\n${indentString}end ${constructOrUnit.unitType} $programUnitName")
+                return EnterHandlerDelegate.Result.DefaultForceIndent
+            }
+
+            // interface
             is FortranInterfaceBlock -> if (constructOrUnit.endInterfaceStmt == null) {
                 val interfaceName = constructOrUnit.interfaceStmt.entityDecl?.name
                 if (interfaceName != null){

--- a/src/main/kotlin/org/jetbrains/fortran/lang/parser/FortranParser.bnf
+++ b/src/main/kotlin/org/jetbrains/fortran/lang/parser/FortranParser.bnf
@@ -1206,7 +1206,7 @@ function_stmt ::= label_decl? prefix? function_ program_unit_name '(' <<list dat
 // R1231
 suffix ::= (language_binding_spec (result_ '(' data_name ')')?) | (result_ '(' data_name ')' (language_binding_spec)?)
 // R1232
-end_function_stmt ::= label_decl? ((end_ (function_ data_name?)?) | (endfunction_ data_name?)) { pin = 2 }
+end_function_stmt ::= label_decl? ((end_ eol+) | (end_ function_ data_name?) | (endfunction_ data_name?)) { pin = 2 }
 // R1233
 subroutine_subprogram ::= subroutine_stmt eol+ block internal_subprogram_part? end_subroutine_stmt {
     pin = 1; extends = program_unit
@@ -1220,7 +1220,7 @@ pin = 3; }
 // R1235
 private dummy_arg ::= '*' | data_name
 // R1236
-end_subroutine_stmt ::= label_decl? ((end_ (subroutine_ data_name?)?) | (endsubroutine_ data_name?)) { pin = 2 }
+end_subroutine_stmt ::= label_decl? ((end_ eol+) | (end_ subroutine_ data_name?) | (endsubroutine_ data_name?)) { pin = 2 }
 // R1237
 separate_module_subprogram ::= mp_subprogram_stmt eol+ block internal_subprogram_part? end_mp_subprogram_stmt {
     pin = 1; extends = program_unit


### PR DESCRIPTION
Enter handler: Detect original code capitalization and insert block end accordingly.
FortranParser:: Restrict the end statements of subroutine and function, so `end module` et. al were not treated as end statement of subroutine block. which may cause the enter handler not insert the end statement automatically when you insert new subroutine to interface block. (this only works only when you insert new subroutine just before the end of parent block)

P.S.
I don't know much about java, so the code is dirty.  but I think this may help you guys to make the plugin more powerful.
  
  