### PR TITLE
Fix processing of end_block_keys

### DIFF
--- a/src/main/kotlin/org/jetbrains/fortran/lang/parser/FortranParser.bnf
+++ b/src/main/kotlin/org/jetbrains/fortran/lang/parser/FortranParser.bnf
@@ -313,9 +313,9 @@ private execution_part_construct ::= !(end_block_keys) ( action_stmt | labeled_d
   recoverWhile=block_recover
 }
 private block_recover ::= !(eol | end_block_keys)
-private end_block_keys ::= !assignment_stmt ( label_decl? ( end_ | endblock_ | endcritical_ | enddo_ | endfunction_ | endif_ | endmodule_ | endprocedure_
-                         | endprogram_ | endselect_ | endsubroutine_ | else_ | elseif_ | endassociate_ | case_ | contains_stmt | endwhere_
-                         | endforall_ | elsewhere_ | (type_ is_) | (class_ is_) | (class_ default_)))
+private end_block_keys ::= !assignment_stmt ( label_decl? ( endblock_ | endcritical_ | enddo_ | endfunction_ | endif_ | endmodule_ | endprocedure_
+                         | endprogram_ | endselect_ | endsubroutine_ | elseif_ | endassociate_ | case_ | contains_stmt | endwhere_
+                         | endforall_ | elsewhere_ | end_ | else_ | (type_ is_) | (class_ is_) | (class_ default_)))
 // R210
 internal_subprogram_part ::= contains_stmt eol+ (eol | internal_subprogram)* {
 pin = 1


### PR DESCRIPTION
END and ELSE keywords should be checked after other keywords starting with the same prefix (ENDDO, ELSEIF, etc.)